### PR TITLE
set_meta now working

### DIFF
--- a/lib/meta_tags_helpers.rb
+++ b/lib/meta_tags_helpers.rb
@@ -68,7 +68,7 @@ module MetaTagsHelpers
     end
   
     def set_meta(options)
-      _meta_tags_hash.deep_merge(normalize_meta_hash(options))
+      _meta_tags_hash.deep_merge!(normalize_meta_hash(options))
     end
   
     def meta_title(val = nil)


### PR DESCRIPTION
Hi, buddy!

You forgot to put bang after deep_merge! and as a result - set_meta didn't work and you couldn't override default settings with it.
