### PR TITLE
Added Site Title Functionality 

### DIFF
--- a/lib/meta_tags_helpers.rb
+++ b/lib/meta_tags_helpers.rb
@@ -64,7 +64,7 @@ module MetaTagsHelpers
   module ActionControllerExtension
     extend ::ActiveSupport::Concern
     included do
-      helper_method :set_meta, :meta_title, :meat_site_title, :meta_description, :meta_image, :meta_type, :normalize_meta_hash
+      helper_method :set_meta, :meta_title, :meta_page_title, :meta_site_title, :meta_description, :meta_image, :meta_type, :normalize_meta_hash
     end
 
     def _meta_tags_hash

--- a/test_app/Gemfile
+++ b/test_app/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 gem 'rails', '4.0.1'
 gem 'jbuilder', '~> 1.2'
 gem "meta-tags-helpers", path: "../"

--- a/test_app/Gemfile
+++ b/test_app/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source 'http://rubygems.org'
 gem 'rails', '4.0.1'
 gem 'jbuilder', '~> 1.2'
 gem "meta-tags-helpers", path: "../"

--- a/test_app/app/controllers/metatags_controller.rb
+++ b/test_app/app/controllers/metatags_controller.rb
@@ -3,15 +3,15 @@ class MetatagsController < ApplicationController
   end
 
   def options
-    @options = { 
-      title: "My title", 
-      description: "My description" 
+    @options = {
+      title: "My title",
+      description: "My description"
     }
   end
 
   def namespaced
     @options = {
-      ns: { 
+      ns: {
         my_custom_meta: "My value"
       }
     }
@@ -30,4 +30,18 @@ class MetatagsController < ApplicationController
   def arrays
     @options = {:og => {:video => { :actor => ["Mikey", "Goofy"] }}}
   end
+
+  def page_title
+    meta_page_title "Page Title"
+  end
+
+  def site_title
+    meta_site_title "Site Title"
+  end
+
+  def full_title
+    meta_page_title "Page Title"
+    meta_site_title "Site Title"
+  end
+
 end

--- a/test_app/app/controllers/metatags_controller.rb
+++ b/test_app/app/controllers/metatags_controller.rb
@@ -31,17 +31,4 @@ class MetatagsController < ApplicationController
     @options = {:og => {:video => { :actor => ["Mikey", "Goofy"] }}}
   end
 
-  def page_title
-    meta_page_title "Page Title"
-  end
-
-  def site_title
-    meta_site_title "Site Title"
-  end
-
-  def full_title
-    meta_page_title "Page Title"
-    meta_site_title "Site Title"
-  end
-
 end

--- a/test_app/app/views/metatags/full_title.html.erb
+++ b/test_app/app/views/metatags/full_title.html.erb
@@ -1,0 +1,2 @@
+<% meta_page_title "Page Title" %>
+<% meta_site_title "Site Title" %>

--- a/test_app/app/views/metatags/page_title.html.erb
+++ b/test_app/app/views/metatags/page_title.html.erb
@@ -1,0 +1,1 @@
+<%  meta_page_title "Page Title" %>

--- a/test_app/app/views/metatags/site_title.html.erb
+++ b/test_app/app/views/metatags/site_title.html.erb
@@ -1,0 +1,1 @@
+<%  meta_site_title "Site Title" %>

--- a/test_app/config/routes.rb
+++ b/test_app/config/routes.rb
@@ -5,4 +5,7 @@ TestApp::Application.routes.draw do
   get "metatags/override_controller"
   get "metatags/override_view"
   get "metatags/arrays"
+  get "metatags/page_title"
+  get "metatags/site_title"
+  get "metatags/full_title"
 end

--- a/test_app/test/controllers/metatags_controller_test.rb
+++ b/test_app/test/controllers/metatags_controller_test.rb
@@ -85,5 +85,22 @@ class MetatagsControllerTest < ActionController::TestCase
     assert_select "meta[property='og:video:actor'][content=?]", "Mikey"
   end
 
+  test "should render page title" do
+    get :page_title
+    assert_response :success
+    assert_select "title", "Page Title"
+  end
+
+  test "should render site title" do
+    get :site_title
+    assert_response :success
+    assert_select "title", "Site Title"
+  end
+
+  test "should render full title" do
+    get :full_title
+    assert_response :success
+    assert_select "title", "Page Title | Site Title"
+  end
 
 end


### PR DESCRIPTION
I added a helper method to render a site title. This allows you to declare a global site title in the application controller and then change the page titles on a controller to controller basis.

If only a site title or normal title are set then it will only render whichever has been set, however if both are set then the title will be render like so `<title>Site Title | Page Title</title>`

The original `meta_title` still works as normal. 

Apologizes for all the differences, my editor removes whitespace.