### PR TITLE
Adding skip tags option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ gem 'meta-tags-helpers', '~> 0.2.0'
 
 ### Examples
 
-You could use the default meta tags (see below) inserting the following snippet of `erb` code in your layout. 
+You could use the default meta tags (see below) inserting the following snippet of `erb` code in your layout.
 
 ``` erb
 <%= meta_tags %>
@@ -31,10 +31,23 @@ if you don't like the defaults you can override them passing other values as a p
     :ns => {
       :my_custom_meta => "a value"
     }
-    ) 
+    )
 %>
 ```
 
+if you would like to skip any default tag from being rendered, declare it as `:skip => "title"` or as `:skip => ["title", "description"]`.
+
+``` erb
+<%= meta_tags(
+    :title => "MyBlog - This is a Blog",
+    :description => "My blog description & a reserved character that will be escaped",
+    :og => {:type => "website"}
+    :ns => {
+      :my_custom_meta => "a value"
+    }
+    )
+%>
+```
 You can further override these values in your controller, views and partials using the `set_meta` method (see below).
 
 ### Generated HTML
@@ -73,9 +86,9 @@ Note that you can also easily render arrays of metas having the same key passing
       :type => "video.movie"
     },
     :video => {
-      :year => 1981, 
+      :year => 1981,
       :actor => ["Kurt Russell", "Lee Van Cleef"]
-    }) 
+    })
 %>
 ```
 
@@ -119,10 +132,10 @@ This is the default options hash:
 
 ``` rb
 default   = {
-  :charset           => "utf-8", 
-  :"X-UA-Compatible" => "IE=edge,chrome=1", 
+  :charset           => "utf-8",
+  :"X-UA-Compatible" => "IE=edge,chrome=1",
   :viewport          => "width=device-width",
-  :"og:url"          => "#{request.url}", 
+  :"og:url"          => "#{request.url}",
   :"og:type"         => "article",
   :"og:title"        => opts[:title],
   :"og:description"  => opts[:description],

--- a/lib/meta_tags_helpers.rb
+++ b/lib/meta_tags_helpers.rb
@@ -49,6 +49,8 @@ module MetaTagsHelpers
         values.each { |v|
           if k.to_s =~ /[a-zA-Z_][-a-zA-Z0-9_.]\:/
             html << "<meta property=\"#{h(k)}\" content=\"#{h(v)}\" />\n"
+          elsif k == 'canonical'
+            html << "<link rel=\"#{h(k)}\" href=\"#{h(v)}\" />\n"
           else
             html << "<meta name=\"#{h(k)}\" content=\"#{h(v)}\" />\n"
           end

--- a/lib/meta_tags_helpers.rb
+++ b/lib/meta_tags_helpers.rb
@@ -36,9 +36,7 @@ module MetaTagsHelpers
         :"og:type"         => "article",
         :"og:title"        => opts[:title],
         :"og:description"  => opts[:description],
-        :"og:image"        => opts[:"og:image"],
-        :"csrf-param"      => request_forgery_protection_token,
-        :"csrf-token"      => form_authenticity_token
+        :"og:image"        => opts[:"og:image"]
       }
 
       override_hash = controller.instance_variable_get("@_meta_tags_hash") || {}

--- a/lib/meta_tags_helpers.rb
+++ b/lib/meta_tags_helpers.rb
@@ -49,7 +49,7 @@ module MetaTagsHelpers
         values.each { |v|
           if k.to_s =~ /[a-zA-Z_][-a-zA-Z0-9_.]\:/
             html << "<meta property=\"#{h(k)}\" content=\"#{h(v)}\" />\n"
-          elsif k == 'canonical'
+          elsif h(k) == 'canonical'
             html << "<link rel=\"#{h(k)}\" href=\"#{h(v)}\" />\n"
           else
             html << "<meta name=\"#{h(k)}\" content=\"#{h(v)}\" />\n"

--- a/lib/meta_tags_helpers.rb
+++ b/lib/meta_tags_helpers.rb
@@ -1,6 +1,6 @@
 # Author::    Maurizio Casimirri (mailto:maurizio.cas@gmail.com)
 # Copyright:: Copyright (c) 2012 Maurizio Casimirri
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
 # "Software"), to deal in the Software without restriction, including
@@ -8,10 +8,10 @@
 # distribute, sublicense, and/or sell copies of the Software, and to
 # permit persons to whom the Software is furnished to do so, subject to
 # the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 # EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 # MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -23,16 +23,16 @@
 module MetaTagsHelpers
 
   module ActionViewExtension
-    
+
     def meta_tags(opts = {})
- 
+
       opts = normalize_meta_hash(opts)
 
       default   = {
-        :charset           => "utf-8", 
-        :"X-UA-Compatible" => "IE=edge,chrome=1", 
+        :charset           => "utf-8",
+        :"X-UA-Compatible" => "IE=edge,chrome=1",
         :viewport          => "width=device-width",
-        :"og:url"          => "#{request.url}", 
+        :"og:url"          => "#{request.url}",
         :"og:type"         => "article",
         :"og:title"        => opts[:title],
         :"og:description"  => opts[:description],
@@ -41,49 +41,49 @@ module MetaTagsHelpers
         :"csrf-token"      => form_authenticity_token
       }
 
-      override_hash = controller.instance_variable_get("@_meta_tags_hash") || {}      
+      override_hash = controller.instance_variable_get("@_meta_tags_hash") || {}
       meta_hash = default.deep_merge(opts).deep_merge(override_hash)
-        
+      meta_hash.reject!{|k,v| opts[:skip].map(&:to_sym).include?(k) || k == :skip } if opts[:skip].present?
       html = ""
       html << "<title>#{h(meta_hash.delete(:title)) }</title>\n"
       meta_hash.each {|k,value_or_array|
         values = value_or_array.is_a?(Array) ? value_or_array : [value_or_array]
         values.each { |v|
           if k.to_s =~ /[a-zA-Z_][-a-zA-Z0-9_.]\:/
-            html << "<meta property=\"#{h(k)}\" content=\"#{h(v)}\" />\n"  
+            html << "<meta property=\"#{h(k)}\" content=\"#{h(v)}\" />\n"
           else
-            html << "<meta name=\"#{h(k)}\" content=\"#{h(v)}\" />\n"  
+            html << "<meta name=\"#{h(k)}\" content=\"#{h(v)}\" />\n"
           end
         }
       }
       html.html_safe
     end
-    
+
   end #~ ActionViewExtension
-  
+
   module ActionControllerExtension
     extend ::ActiveSupport::Concern
     included do
       helper_method :set_meta, :meta_title, :meta_description, :meta_image, :meta_type, :normalize_meta_hash
     end
-    
+
     def _meta_tags_hash
       @_meta_tags_hash ||= {}
     end
-  
+
     def set_meta(options)
       _meta_tags_hash.deep_merge!(normalize_meta_hash(options))
     end
-  
+
     def meta_title(val = nil)
       if val
         @_meta_title = val
         set_meta(:title => val)
       end
-      
+
       @_meta_title
     end
-      
+
     def meta_description(val = nil)
       if val
         @_meta_description = val
@@ -91,7 +91,7 @@ module MetaTagsHelpers
       end
       @_meta_description
     end
-      
+
     def meta_image(val = nil)
       if val
         @_meta_image = val
@@ -107,9 +107,9 @@ module MetaTagsHelpers
       end
       @_meta_type
     end
-    
+
     protected
-    
+
     def normalize_meta_hash(hash)
       normalized = {}
       normalize_meta_hash_walker(hash, normalized)
@@ -117,14 +117,14 @@ module MetaTagsHelpers
     end
 
     private
-    
+
     def normalize_meta_hash_walker(hash, normalized, current = nil)
       hash.each do |k, v|
         thisPath = current ? current.dup : []
         thisPath << k.to_s
 
         if v.is_a?(Hash)
-          normalize_meta_hash_walker(v, normalized, thisPath) 
+          normalize_meta_hash_walker(v, normalized, thisPath)
         elsif v
           key = thisPath.join ":"
           normalized[:"#{key}"] = v

--- a/meta-tags-helpers.gemspec
+++ b/meta-tags-helpers.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "meta-tags-helpers"
-  spec.version       = "0.2.0"
+  spec.version       = "0.2.1"
   spec.authors       = ["mcasimir"]
   spec.email         = ["maurizio.cas@gmail.com"]
   spec.description   = "Rails meta tags helpers"

--- a/meta-tags-helpers.gemspec
+++ b/meta-tags-helpers.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "meta-tags-helpers"
-  spec.version       = "0.2.1"
+  spec.version       = "0.2.2"
   spec.authors       = ["mcasimir"]
   spec.email         = ["maurizio.cas@gmail.com"]
   spec.description   = "Rails meta tags helpers"


### PR DESCRIPTION
You can pass `:skip` options when calling `meta_tags`on views to skip some default options